### PR TITLE
Remove ice hole manager and fishingType

### DIFF
--- a/__tests__/entities/FishAI.test.js
+++ b/__tests__/entities/FishAI.test.js
@@ -26,10 +26,9 @@ import {
 describe('FishAI - Constructor and Initialization', () => {
   test('Creates with default properties', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(ai.fish).toBe(fish);
-    expect(ai.fishingType).toBe(GameConfig.FISHING_TYPE_ICE);
     expect(ai.state).toBe(Constants.FISH_STATE.IDLE);
     expect(ai.targetX).toBeNull();
     expect(ai.targetY).toBeNull();
@@ -40,7 +39,7 @@ describe('FishAI - Constructor and Initialization', () => {
 
     // Test multiple times due to randomness
     for (let i = 0; i < 10; i++) {
-      const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+      const ai = new FishAI(fish);
       expect(ai.alertness).toBeGreaterThanOrEqual(0.5);
       expect(ai.alertness).toBeLessThanOrEqual(1.0);
     }
@@ -50,7 +49,7 @@ describe('FishAI - Constructor and Initialization', () => {
     const fish = createMockFish();
 
     for (let i = 0; i < 10; i++) {
-      const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+      const ai = new FishAI(fish);
       expect(ai.baseAggressiveness).toBeGreaterThanOrEqual(0.5);
       expect(ai.baseAggressiveness).toBeLessThanOrEqual(1.0);
     }
@@ -61,7 +60,7 @@ describe('FishAI - Constructor and Initialization', () => {
     const directions = new Set();
 
     for (let i = 0; i < 20; i++) {
-      const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+      const ai = new FishAI(fish);
       directions.add(ai.idleDirection);
     }
 
@@ -73,7 +72,7 @@ describe('FishAI - Constructor and Initialization', () => {
 
   test('Sets default strike attempts to 1', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(ai.strikeAttempts).toBe(0);
     expect(ai.maxStrikeAttempts).toBe(1);
@@ -81,7 +80,7 @@ describe('FishAI - Constructor and Initialization', () => {
 
   test('Calculates depth preference within expected range', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(ai.depthPreference).toBeGreaterThanOrEqual(GameConfig.LAKE_TROUT_PREFERRED_DEPTH_MIN);
     expect(ai.depthPreference).toBeLessThanOrEqual(GameConfig.LAKE_TROUT_PREFERRED_DEPTH_MAX);
@@ -89,7 +88,7 @@ describe('FishAI - Constructor and Initialization', () => {
 
   test('Calculates speed preference within expected range', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(ai.speedPreference).toBeGreaterThanOrEqual(1.5);
     expect(ai.speedPreference).toBeLessThanOrEqual(3.5);
@@ -97,7 +96,7 @@ describe('FishAI - Constructor and Initialization', () => {
 
   test('Initializes baitfish hunting properties', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(ai.targetBaitfishCloud).toBeNull();
     expect(ai.targetBaitfish).toBeNull();
@@ -106,14 +105,14 @@ describe('FishAI - Constructor and Initialization', () => {
 
   test('Initializes thermocline behavior flag', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(ai.returningToThermocline).toBe(false);
   });
 
   test('Initializes with no bumped lure flag', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(ai.hasBumpedLure).toBe(false);
   });
@@ -122,7 +121,7 @@ describe('FishAI - Constructor and Initialization', () => {
 describe('FishAI - Species-Specific Initialization (Northern Pike)', () => {
   test('Northern Pike are initialized as ambush predators', () => {
     const pike = createMockFish({ species: 'northern_pike' });
-    const ai = new FishAI(pike, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(pike);
 
     expect(ai.isAmbushPredator).toBe(true);
   });
@@ -133,35 +132,35 @@ describe('FishAI - Species-Specific Initialization (Northern Pike)', () => {
       worldX: 1234,
       y: 567
     });
-    const ai = new FishAI(pike, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(pike);
 
     expect(ai.ambushPosition).toEqual({ x: 1234, y: 567 });
   });
 
   test('Northern Pike have ambush radius property', () => {
     const pike = createMockFish({ species: 'northern_pike' });
-    const ai = new FishAI(pike, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(pike);
 
     expect(ai.ambushRadius).toBe(50);
   });
 
   test('Northern Pike have extended strike range', () => {
     const pike = createMockFish({ species: 'northern_pike' });
-    const ai = new FishAI(pike, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(pike);
 
     expect(ai.strikeRange).toBe(60);
   });
 
   test('Northern Pike have burst speed multiplier', () => {
     const pike = createMockFish({ species: 'northern_pike' });
-    const ai = new FishAI(pike, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(pike);
 
     expect(ai.burstSpeed).toBe(2.5);
   });
 
   test('Non-pike species are not ambush predators', () => {
     const trout = createMockFish({ species: 'lake_trout' });
-    const ai = new FishAI(trout, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(trout);
 
     expect(ai.isAmbushPredator).toBe(false);
   });
@@ -170,21 +169,21 @@ describe('FishAI - Species-Specific Initialization (Northern Pike)', () => {
 describe('FishAI - Species-Specific Initialization (Smallmouth Bass)', () => {
   test('Smallmouth Bass are initialized to circle before strike', () => {
     const bass = createMockFish({ species: 'smallmouth_bass' });
-    const ai = new FishAI(bass, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(bass);
 
     expect(ai.circlesBeforeStrike).toBe(true);
   });
 
   test('Smallmouth Bass start not circling', () => {
     const bass = createMockFish({ species: 'smallmouth_bass' });
-    const ai = new FishAI(bass, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(bass);
 
     expect(ai.isCircling).toBe(false);
   });
 
   test('Smallmouth Bass have circle angle initialized', () => {
     const bass = createMockFish({ species: 'smallmouth_bass' });
-    const ai = new FishAI(bass, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(bass);
 
     expect(ai.circleAngle).toBeGreaterThanOrEqual(0);
     expect(ai.circleAngle).toBeLessThanOrEqual(Math.PI * 2);
@@ -192,14 +191,14 @@ describe('FishAI - Species-Specific Initialization (Smallmouth Bass)', () => {
 
   test('Smallmouth Bass have circle radius', () => {
     const bass = createMockFish({ species: 'smallmouth_bass' });
-    const ai = new FishAI(bass, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(bass);
 
     expect(ai.circleRadius).toBe(35);
   });
 
   test('Smallmouth Bass have circle speed', () => {
     const bass = createMockFish({ species: 'smallmouth_bass' });
-    const ai = new FishAI(bass, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(bass);
 
     expect(ai.circleSpeed).toBe(0.08);
   });
@@ -209,7 +208,7 @@ describe('FishAI - Species-Specific Initialization (Smallmouth Bass)', () => {
     const directions = new Set();
 
     for (let i = 0; i < 20; i++) {
-      const ai = new FishAI(bass, GameConfig.FISHING_TYPE_ICE);
+      const ai = new FishAI(bass);
       directions.add(ai.circleDirection);
     }
 
@@ -220,7 +219,7 @@ describe('FishAI - Species-Specific Initialization (Smallmouth Bass)', () => {
 
   test('Smallmouth Bass have circle time counters', () => {
     const bass = createMockFish({ species: 'smallmouth_bass' });
-    const ai = new FishAI(bass, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(bass);
 
     expect(ai.circleTime).toBe(0);
     expect(ai.maxCircleTime).toBe(120);
@@ -228,7 +227,7 @@ describe('FishAI - Species-Specific Initialization (Smallmouth Bass)', () => {
 
   test('Non-bass species do not circle', () => {
     const trout = createMockFish({ species: 'lake_trout' });
-    const ai = new FishAI(trout, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(trout);
 
     expect(ai.circlesBeforeStrike).toBe(false);
   });
@@ -242,7 +241,7 @@ describe('FishAI - Aggressiveness Getter', () => {
         aggressivenessBonus: 0
       }
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const aggressiveness = ai.aggressiveness;
     expect(aggressiveness).toBeGreaterThanOrEqual(0.1);
@@ -256,7 +255,7 @@ describe('FishAI - Aggressiveness Getter', () => {
         aggressivenessBonus: 0.3
       }
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     ai.baseAggressiveness = 0.5;
 
     expect(ai.aggressiveness).toBe(0.8); // 0.5 + 0.3
@@ -269,7 +268,7 @@ describe('FishAI - Aggressiveness Getter', () => {
         aggressivenessBonus: 0.8
       }
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     ai.baseAggressiveness = 0.9;
 
     expect(ai.aggressiveness).toBe(1.0); // Clamped from 1.7
@@ -282,7 +281,7 @@ describe('FishAI - Aggressiveness Getter', () => {
         aggressivenessBonus: -0.5
       }
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     ai.baseAggressiveness = 0.2;
 
     expect(ai.aggressiveness).toBe(0.1); // Clamped from -0.3
@@ -295,7 +294,7 @@ describe('FishAI - Aggressiveness Getter', () => {
         aggressivenessBonus: 0
       }
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     ai.baseAggressiveness = 0.7;
 
     expect(ai.aggressiveness).toBe(0.7);
@@ -305,24 +304,24 @@ describe('FishAI - Aggressiveness Getter', () => {
 describe('FishAI - getStrikeDistance', () => {
   test('Northern Pike have longer strike distance', () => {
     const pike = createMockFish({ species: 'northern_pike' });
-    const ai = new FishAI(pike, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(pike);
 
     expect(ai.getStrikeDistance()).toBe(60); // Pike-specific strike range
   });
 
   test('Non-pike species use default strike distance', () => {
     const trout = createMockFish({ species: 'lake_trout' });
-    const ai = new FishAI(trout, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(trout);
 
     expect(ai.getStrikeDistance()).toBe(GameConfig.STRIKE_DISTANCE);
   });
 
   test('Pike strike distance is greater than default', () => {
     const pike = createMockFish({ species: 'northern_pike' });
-    const pikeAi = new FishAI(pike, GameConfig.FISHING_TYPE_ICE);
+    const pikeAi = new FishAI(pike);
 
     const trout = createMockFish({ species: 'lake_trout' });
-    const troutAi = new FishAI(trout, GameConfig.FISHING_TYPE_ICE);
+    const troutAi = new FishAI(trout);
 
     expect(pikeAi.getStrikeDistance()).toBeGreaterThan(troutAi.getStrikeDistance());
   });
@@ -331,7 +330,7 @@ describe('FishAI - getStrikeDistance', () => {
 describe('FishAI - calculateDepthPreference', () => {
   test('Returns depth within preferred range', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const depth = ai.calculateDepthPreference();
     expect(depth).toBeGreaterThanOrEqual(GameConfig.LAKE_TROUT_PREFERRED_DEPTH_MIN);
@@ -340,7 +339,7 @@ describe('FishAI - calculateDepthPreference', () => {
 
   test('Different calls return different values (uses randomness)', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const depths = new Set();
     for (let i = 0; i < 10; i++) {
@@ -355,7 +354,7 @@ describe('FishAI - calculateDepthPreference', () => {
 describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
   test('Does not enter frenzy when alone', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     ai.detectFrenzy(lure, [fish]); // Only this fish
@@ -365,7 +364,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Can enter frenzy when other fish are interested', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     // Create other excited fish nearby
     const excitedFish = createMockFishArray(2, Constants.FISH_STATE.INTERESTED, 490, 95);
@@ -390,7 +389,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Frenzy duration scales with number of excited fish', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     // Test with 1 excited fish
     const excitedFish1 = createMockFishArray(1, Constants.FISH_STATE.CHASING, 490, 95);
@@ -429,7 +428,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Frenzy intensity scales with number of excited fish', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const excitedFish = createMockFishArray(3, Constants.FISH_STATE.STRIKING, 490, 95);
     const lure = createMockLure({ x: 500, y: 100 });
@@ -450,7 +449,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Frenzying fish get multiple strike attempts', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const excitedFish = createMockFishArray(2, Constants.FISH_STATE.CHASING, 490, 95);
     const lure = createMockLure({ x: 500, y: 100 });
@@ -471,7 +470,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Fish in frenzy state changes to interested', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const excitedFish = createMockFishArray(2, Constants.FISH_STATE.CHASING, 490, 95);
     const lure = createMockLure({ x: 500, y: 100 });
@@ -492,7 +491,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
   test('Frenzy triggers interest flash on fish', () => {
     const fish = createMockFish({ inFrenzy: false });
     fish.triggerInterestFlash = jest.fn();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const excitedFish = createMockFishArray(2, Constants.FISH_STATE.CHASING, 490, 95);
     const lure = createMockLure({ x: 500, y: 100 });
@@ -514,7 +513,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Does not count self when detecting excited fish', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     ai.state = Constants.FISH_STATE.CHASING; // This fish is excited
 
     const lure = createMockLure();
@@ -528,7 +527,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Detects excited fish in HUNTING_BAITFISH state', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const huntingFish = createMockFishArray(2, Constants.FISH_STATE.HUNTING_BAITFISH, 490, 95);
     const lure = createMockLure({ x: 500, y: 100 });
@@ -552,7 +551,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Detects excited fish in FEEDING state', () => {
     const fish = createMockFish({ inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const feedingFish = createMockFishArray(2, Constants.FISH_STATE.FEEDING, 490, 95);
     const lure = createMockLure({ x: 500, y: 100 });
@@ -576,7 +575,7 @@ describe('FishAI - detectFrenzy (Multi-Fish Interaction)', () => {
 
   test('Only detects fish within detection range', () => {
     const fish = createMockFish({ x: 500, y: 100, inFrenzy: false });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     // Create excited fish FAR away (beyond detection range * 3)
     const farFish = createMockFish({
@@ -612,7 +611,7 @@ describe('FishAI - detectFrenzy (Vertical Strike)', () => {
       },
       inFrenzy: false
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     // Lure above fish
     const lure = createMockLure({ x: 510, y: 100 });
@@ -644,7 +643,7 @@ describe('FishAI - detectFrenzy (Vertical Strike)', () => {
       },
       inFrenzy: false
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     // Lure above fish (needs to be at least 20px above and within horizontal range)
     const lure = createMockLure({ x: 510, y: 370 }); // Changed from 100 to 370 to be closer
@@ -676,7 +675,7 @@ describe('FishAI - detectFrenzy (Vertical Strike)', () => {
       },
       inFrenzy: false
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const lure = createMockLure({ x: 510, y: 100 });
 
@@ -704,7 +703,7 @@ describe('FishAI - detectFrenzy (Vertical Strike)', () => {
       },
       inFrenzy: false
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const lure = createMockLure({ x: 510, y: 95 });
 
@@ -734,7 +733,7 @@ describe('FishAI - detectFrenzy (Vertical Strike)', () => {
       },
       inFrenzy: false
     });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     const lure = createMockLure({ x: 510, y: 30 });
 
@@ -755,7 +754,7 @@ describe('FishAI - detectFrenzy (Vertical Strike)', () => {
 describe('FishAI - update() Method (Decision Cooldown)', () => {
   test('Does not make decisions during cooldown', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     ai.lastDecisionTime = 1000;
@@ -770,7 +769,7 @@ describe('FishAI - update() Method (Decision Cooldown)', () => {
 
   test('Makes decisions after cooldown expires', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     ai.lastDecisionTime = 1000;
@@ -784,7 +783,7 @@ describe('FishAI - update() Method (Decision Cooldown)', () => {
 
   test('Updates lastDecisionTime when decision is made', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     ai.lastDecisionTime = 0;
@@ -799,7 +798,7 @@ describe('FishAI - update() Method (Decision Cooldown)', () => {
 describe('FishAI - update() Method (Nature Mode - No Lure)', () => {
   test('Fish idle when no lure and no baitfish', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     ai.update(null, 1000, [fish], []);
 
@@ -808,7 +807,7 @@ describe('FishAI - update() Method (Nature Mode - No Lure)', () => {
 
   test('Nature mode does not crash without lure', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     expect(() => {
       ai.update(null, 1000, [fish], []);
@@ -819,7 +818,7 @@ describe('FishAI - update() Method (Nature Mode - No Lure)', () => {
 describe('FishAI - Edge Cases and Type Safety', () => {
   test('Handles undefined allFish array', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     expect(() => {
@@ -829,7 +828,7 @@ describe('FishAI - Edge Cases and Type Safety', () => {
 
   test('Handles empty allFish array', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     expect(() => {
@@ -839,7 +838,7 @@ describe('FishAI - Edge Cases and Type Safety', () => {
 
   test('Handles undefined baitfishClouds array', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     expect(() => {
@@ -849,7 +848,7 @@ describe('FishAI - Edge Cases and Type Safety', () => {
 
   test('Handles empty baitfishClouds array', () => {
     const fish = createMockFish();
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     const lure = createMockLure();
 
     expect(() => {
@@ -863,7 +862,7 @@ describe('FishAI - Edge Cases and Type Safety', () => {
 
     // FishAI doesn't validate depthZone in constructor
     // This test verifies it doesn't crash, but accessing aggressiveness will fail
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
     expect(ai).toBeDefined();
 
     // Accessing aggressiveness getter should throw because it accesses fish.depthZone.aggressivenessBonus
@@ -874,7 +873,7 @@ describe('FishAI - Edge Cases and Type Safety', () => {
 
   test('Handles fish with invalid species', () => {
     const fish = createMockFish({ species: 'invalid_species' });
-    const ai = new FishAI(fish, GameConfig.FISHING_TYPE_ICE);
+    const ai = new FishAI(fish);
 
     // Should not crash, should just not have species-specific behaviors
     expect(ai.isAmbushPredator).toBe(false);

--- a/src/entities/Fish.js
+++ b/src/entities/Fish.js
@@ -10,11 +10,11 @@ import YellowPerch from '../models/species/YellowPerch.js';
  * All game logic is delegated to the model
  */
 export class Fish {
-    constructor(scene, x, y, size = 'MEDIUM', fishingType = null, species = 'lake_trout') {
+    constructor(scene, x, y, size = 'MEDIUM', species = 'lake_trout') {
         this.scene = scene;
 
         // Create the appropriate model based on species
-        this.model = this.createModel(scene, x, y, size, fishingType, species);
+        this.model = this.createModel(scene, x, y, size, species);
 
         // Phaser-specific visual elements
         this.graphics = scene.add.graphics();
@@ -32,18 +32,18 @@ export class Fish {
     /**
      * Factory method to create the appropriate species model
      */
-    createModel(scene, x, y, size, fishingType, species) {
+    createModel(scene, x, y, size, species) {
         switch(species) {
             case 'lake_trout':
-                return new LakeTrout(scene, x, y, size, fishingType);
+                return new LakeTrout(scene, x, y, size);
             case 'northern_pike':
-                return new NorthernPike(scene, x, y, size, fishingType);
+                return new NorthernPike(scene, x, y, size);
             case 'smallmouth_bass':
-                return new SmallmouthBass(scene, x, y, size, fishingType);
+                return new SmallmouthBass(scene, x, y, size);
             case 'yellow_perch_large':
-                return new YellowPerch(scene, x, y, size, fishingType);
+                return new YellowPerch(scene, x, y, size);
             default:
-                return new LakeTrout(scene, x, y, size, fishingType);
+                return new LakeTrout(scene, x, y, size);
         }
     }
 

--- a/src/entities/FishAI.js
+++ b/src/entities/FishAI.js
@@ -3,9 +3,8 @@ import { Constants, Utils } from '../utils/Constants.js';
 import { calculateDietPreference } from '../config/SpeciesData.js';
 
 export class FishAI {
-    constructor(fish, fishingType) {
+    constructor(fish) {
         this.fish = fish;
-        this.fishingType = fishingType; // Store fishing type for thermocline behavior
         this.state = Constants.FISH_STATE.IDLE;
         this.targetX = null;
         this.targetY = null;

--- a/src/models/fish.js
+++ b/src/models/fish.js
@@ -22,14 +22,12 @@ const FEMALE_NAMES = [
  * Adds AI, catching mechanics, and predator-specific behaviors
  */
 export class Fish extends AquaticOrganism {
-    constructor(scene, x, y, size = 'MEDIUM', fishingType = null, species = 'lake_trout') {
+    constructor(scene, x, y, size = 'MEDIUM', species = 'lake_trout') {
         // Get species data for super constructor
         const speciesData = getPredatorSpecies(species);
 
         // Call parent constructor with base properties
         super(scene, x, y, species, speciesData);
-
-        this.fishingType = fishingType || scene.fishingType;
 
         // Fish-specific size and weight properties
         this.size = Constants.FISH_SIZE[size];
@@ -55,7 +53,7 @@ export class Fish extends AquaticOrganism {
         this.speed = this.baseSpeed * this.depthZone.speedMultiplier;
 
         // AI controller (heavy - not used by baitfish)
-        this.ai = new FishAI(this, this.fishingType);
+        this.ai = new FishAI(this);
 
         // Sonar properties (visual rendering handled by entity layer)
         this.sonarStrength = this.calculateSonarStrength();

--- a/src/models/species/LakeTrout.js
+++ b/src/models/species/LakeTrout.js
@@ -7,8 +7,8 @@ import GameConfig from '../../config/GameConfig.js';
  * Salvelinus namaycush
  */
 export class LakeTrout extends Fish {
-    constructor(scene, x, y, size = 'MEDIUM', fishingType = null) {
-        super(scene, x, y, size, fishingType, 'lake_trout');
+    constructor(scene, x, y, size = 'MEDIUM') {
+        super(scene, x, y, size, 'lake_trout');
 
         // Lake trout are MUCH hungrier - voracious predators
         this.hunger = Utils.randomBetween(80, 100);

--- a/src/models/species/NorthernPike.js
+++ b/src/models/species/NorthernPike.js
@@ -6,8 +6,8 @@ import { Utils } from '../../utils/Constants.js';
  * Esox lucius
  */
 export class NorthernPike extends Fish {
-    constructor(scene, x, y, size = 'MEDIUM', fishingType = null) {
-        super(scene, x, y, size, fishingType, 'northern_pike');
+    constructor(scene, x, y, size = 'MEDIUM') {
+        super(scene, x, y, size, 'northern_pike');
     }
 
     calculateLength() {

--- a/src/models/species/SmallmouthBass.js
+++ b/src/models/species/SmallmouthBass.js
@@ -6,8 +6,8 @@ import { Utils } from '../../utils/Constants.js';
  * Micropterus dolomieu
  */
 export class SmallmouthBass extends Fish {
-    constructor(scene, x, y, size = 'MEDIUM', fishingType = null) {
-        super(scene, x, y, size, fishingType, 'smallmouth_bass');
+    constructor(scene, x, y, size = 'MEDIUM') {
+        super(scene, x, y, size, 'smallmouth_bass');
     }
 
     calculateLength() {

--- a/src/models/species/YellowPerch.js
+++ b/src/models/species/YellowPerch.js
@@ -6,8 +6,8 @@ import { Utils } from '../../utils/Constants.js';
  * Perca flavescens
  */
 export class YellowPerch extends Fish {
-    constructor(scene, x, y, size = 'MEDIUM', fishingType = null) {
-        super(scene, x, y, size, fishingType, 'yellow_perch_large');
+    constructor(scene, x, y, size = 'MEDIUM') {
+        super(scene, x, y, size, 'yellow_perch_large');
     }
 
     calculateLength() {

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -161,7 +161,7 @@ export class GameScene extends Phaser.Scene {
             this.hideUnusedPanels();
 
             // Set up the sonar display
-            this.sonarDisplay = new SonarDisplay(this, this.fishingType);
+            this.sonarDisplay = new SonarDisplay(this);
 
             // Create the player's lure - start at surface (0 feet)
             this.lure = new Lure(this, GameConfig.CANVAS_WIDTH / 2, 0);
@@ -515,7 +515,7 @@ export class GameScene extends Phaser.Scene {
             const y = depth * GameConfig.DEPTH_SCALE;
 
             // All TROPHY size
-            const fish = new Fish(this, worldX, y, 'TROPHY', this.fishingType, speciesName);
+            const fish = new Fish(this, worldX, y, 'TROPHY', speciesName);
 
             // Set movement direction
             fish.ai.idleDirection = Math.random() < 0.5 ? -1 : 1;
@@ -540,7 +540,7 @@ export class GameScene extends Phaser.Scene {
             // Random baitfish species
             const baitSpecies = ['alewife', 'rainbow_smelt', 'yellow_perch'][Math.floor(Math.random() * 3)];
 
-            const cloud = new BaitfishCloud(this, worldX, y, cloudSize, this.fishingType, baitSpecies);
+            const cloud = new BaitfishCloud(this, worldX, y, cloudSize, baitSpecies);
 
             this.baitfishClouds.push(cloud);
             console.log(`  Spawned large ${baitSpecies} cloud (${cloudSize} fish) at ${depth}ft`);

--- a/src/scenes/systems/SpawningSystem.js
+++ b/src/scenes/systems/SpawningSystem.js
@@ -182,7 +182,7 @@ export class SpawningSystem {
         const y = depth * depthScale;
 
         // Create the fish with species parameter (worldX will be used internally, x will be calculated for screen)
-        const fish = new Fish(this.scene, worldX, y, size, this.scene.fishingType || 'observation', species);
+        const fish = new Fish(this.scene, worldX, y, size, species);
 
         // Set initial movement direction - fish swim toward and past the player
         if (fromLeft) {
@@ -501,7 +501,7 @@ export class SpawningSystem {
 
         // Create fish with max hunger and low health (size MEDIUM for balance)
         // Emergency fish is always lake trout for consistency
-        const fish = new Fish(this.scene, worldX, y, 'MEDIUM', this.scene.fishingType, 'lake_trout');
+        const fish = new Fish(this.scene, worldX, y, 'MEDIUM', 'lake_trout');
         fish.hunger = 100; // Max hunger - very motivated!
         fish.health = 30; // Low health makes it easier to catch
         fish.isEmergencyFish = true; // Mark as emergency fish

--- a/src/utils/SonarDisplay.js
+++ b/src/utils/SonarDisplay.js
@@ -2,9 +2,8 @@ import GameConfig from '../config/GameConfig.js';
 import { BAITFISH_SPECIES } from '../config/SpeciesData.js';
 
 export class SonarDisplay {
-    constructor(scene, fishingType) {
+    constructor(scene) {
         this.scene = scene;
-        this.fishingType = fishingType; // Track fishing type for rendering
         this.graphics = scene.add.graphics();
         this.graphics.setDepth(0); // Render as background
         this.gridOffset = 0;


### PR DESCRIPTION
Removed the vestigial fishingType parameter that was originally used to distinguish between ice fishing, kayak, and motorboat modes. This parameter was stored but never actually used in the codebase.

Changes:
- Removed fishingType from all fish species constructors (LakeTrout, NorthernPike, SmallmouthBass, YellowPerch)
- Removed fishingType from base Fish model and entity classes
- Removed fishingType from FishAI constructor
- Removed fishingType from SonarDisplay constructor
- Updated all call sites in SpawningSystem.js and GameScene.js
- Updated test files to reflect the removed parameter

This simplifies the codebase by removing an unused parameter that was passed through multiple layers but never referenced.