### PR TITLE
Fix Electron app launch by converting to ES modules

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -1,5 +1,9 @@
-const { app, BrowserWindow } = require('electron');
-const path = require('path');
+import { app, BrowserWindow } from 'electron';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 let mainWindow;
 


### PR DESCRIPTION
## Summary
- Fixes Electron app crash on launch
- Converts `electron-main.js` from CommonJS to ES module syntax
- Maintains compatibility with project's `"type": "module"` configuration

## Changes
- Replaced `require()` with `import` statements
- Added `__filename` and `__dirname` polyfills for ES modules
- No functional changes to Electron behavior

## Test Plan
- [x] Run `npm run electron` - app launches successfully
- [x] Window opens with correct dimensions (1280x720)
- [x] Game loads from dist/index.html
- [x] No console errors

## Context
This fixes the "require is not defined in ES module scope" error that was preventing the Electron wrapper from launching. The fix ensures both the web build (for itch.io) and Electron build (for Steam) work correctly from a single codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)