### PR TITLE
Fix Fish species getter conflict causing TypeError

### DIFF
--- a/src/entities/Fish.js
+++ b/src/entities/Fish.js
@@ -13,7 +13,8 @@ import { BAITFISH_SPECIES } from '../config/SpeciesData.js';
 export class Fish {
     constructor(scene, x, y, size = 'MEDIUM', species = 'lake_trout') {
         this.scene = scene;
-        this.species = species;
+        // Store species name internally (not as property, since we have a getter)
+        this._speciesName = species;
 
         // Detect if this is a baitfish species
         this.isBaitfish = BAITFISH_SPECIES.hasOwnProperty(species);
@@ -43,7 +44,7 @@ export class Fish {
      * Initialize schooling behavior for baitfish
      */
     initializeSchoolingBehavior() {
-        const speciesData = BAITFISH_SPECIES[this.species];
+        const speciesData = BAITFISH_SPECIES[this._speciesName];
 
         // Boids parameters based on species schooling density
         const densityMap = {
@@ -442,7 +443,7 @@ export class Fish {
             if (other === this) return;
 
             // Only school with same species
-            if (other.species !== this.species) return;
+            if (other._speciesName !== this._speciesName) return;
 
             // Check distance
             const dx = other.model.worldX - this.model.worldX;


### PR DESCRIPTION
## Issue
Constructor in `Fish.js` tried to set `this.species = species` but line 301 has a getter `get species()`, causing:
```
Uncaught TypeError: Cannot set property species of #<Fish> which has only a getter
```

## Root Cause
You cannot set a property that has a getter defined without a setter.

## Fix
- Store species internally as `this._speciesName` in constructor
- Update `initializeSchoolingBehavior()` to use `this._speciesName`
- Update `findNearbySchoolmates()` species comparison to use `this._speciesName`
- Getter at line 301 (`get species()`) still works, delegates to `model.species`

## Testing
- Game now loads without errors
- Fish spawn correctly
- Baitfish schooling works (uses `_speciesName` for species matching)
- Public API unchanged (external code can still use `fish.species` getter)

This is a critical hotfix for main branch.